### PR TITLE
Remove unquoting connection opts in wcar* macro example

### DIFF
--- a/wiki/1-Getting-started.md
+++ b/wiki/1-Getting-started.md
@@ -36,7 +36,7 @@ This `my-wcar-opts` can then be provided to Carmine's `wcar` ("with Carmine") AP
 You can create a `wcar` partial for convenience:
 
 ```clojure
-(defmacro wcar* [& body] `(car/wcar ~my-wcar-opts ~@body))
+(defmacro wcar* [& body] `(car/wcar my-wcar-opts ~@body))
 ```
 
 # Usage


### PR DESCRIPTION
The wcar* macro example includes unquoting the `my-wcar-opts` object, which should not be the case.

The following code:
```clojure
(defonce my-conn-pool (car/connection-pool {})) ; Create a new stateful pool
(def     my-conn-spec {:uri "http://localhost:6379/"})
(def     my-wcar-opts {:pool my-conn-pool, :spec my-conn-spec})

(defmacro wcar* [& body] `(car/wcar ~my-wcar-opts ~@body))

(wcar* (car/ping))
```
results in an error:
<details><summary>Error log</summary>
<p>
```
Syntax error compiling fn* at (/private/var/folders/2k/627bf4ks6mq1_y113nlg3zl00000gn/T/form-init16604705523553863047.clj:1:1).
Can't embed object in code, maybe print-dup not defined: GenericKeyedObjectPool [maxTotal=-1, blockWhenExhausted=true, maxWaitDuration=PT-0.001S, lifo=true, fairness=false, testOnCreate=false, testOnBorrow=false, testOnReturn=false, testWhileIdle=true, durationBetweenEvictionRuns=PT30S, numTestsPerEvictionRun=-1, minEvictableIdleTimeDuration=PT1M, softMinEvictableIdleTimeDuration=PT-0.001S, evictionPolicy=org.apache.commons.pool2.impl.DefaultEvictionPolicy@73bf6174, closeLock=java.lang.Object@51674a03, closed=false, evictionLock=java.lang.Object@a8d9057, evictor=org.apache.commons.pool2.impl.BaseGenericObjectPool$Evictor [scheduledFuture=java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@7fe0144[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@649e00a7[Wrapped task = org.apache.commons.pool2.impl.EvictionTimer$WeakRunner@6ca27981]]], evictionIterator=null, factoryClassLoader=java.lang.ref.WeakReference@611736c4, oname=org.apache.commons.pool2:type=GenericKeyedObjectPool,name=pool, creationStackTrace=java.lang.Exception
	at org.apache.commons.pool2.impl.BaseGenericObjectPool.<init>(BaseGenericObjectPool.java:420)
	at org.apache.commons.pool2.impl.GenericKeyedObjectPool.<init>(GenericKeyedObjectPool.java:264)
	at org.apache.commons.pool2.impl.GenericKeyedObjectPool.<init>(GenericKeyedObjectPool.java:248)
	at taoensso.carmine.connections$fn__7484.invokeStatic(connections.clj:228)
	at taoensso.carmine.connections$fn__7484.invoke(connections.clj:205)
	at clojure.lang.AFn.applyToHelper(AFn.java:154)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.core$apply.invoke(core.clj:662)
	at taoensso.encore$cache$fn__2549$fn__2553.invoke(encore.cljc:3110)
	at clojure.lang.Delay.deref(Delay.java:42)
	at clojure.core$deref.invokeStatic(core.clj:2337)
	at clojure.core$deref.invoke(core.clj:2323)
	at taoensso.encore$cache$fn__2549.doInvoke(encore.cljc:3098)
	at clojure.lang.RestFn.invoke(RestFn.java:421)
	at taoensso.carmine$connection_pool.invokeStatic(carmine.clj:63)
	at taoensso.carmine$connection_pool.invoke(carmine.clj:37)
	at clj_matchmaking.core$eval8539.invokeStatic(core.clj:5)
	at clj_matchmaking.core$eval8539.invoke(core.clj:5)
	at clojure.lang.Compiler.eval(Compiler.java:7194)
	at clojure.lang.Compiler.load(Compiler.java:7653)
	at clojure.lang.RT.loadResourceScript(RT.java:381)
	at clojure.lang.RT.loadResourceScript(RT.java:372)
	at clojure.lang.RT.load(RT.java:459)
	at clojure.lang.RT.load(RT.java:424)
	at clojure.core$load$fn__6908.invoke(core.clj:6161)
	at clojure.core$load.invokeStatic(core.clj:6160)
	at clojure.core$load.doInvoke(core.clj:6144)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at clojure.core$load_one.invokeStatic(core.clj:5933)
	at clojure.core$load_one.invoke(core.clj:5928)
	at clojure.core$load_lib$fn__6850.invoke(core.clj:5975)
	at clojure.core$load_lib.invokeStatic(core.clj:5974)
	at clojure.core$load_lib.doInvoke(core.clj:5953)
	at clojure.lang.RestFn.applyTo(RestFn.java:142)
	at clojure.core$apply.invokeStatic(core.clj:669)
	at clojure.core$load_libs.invokeStatic(core.clj:6016)
	at clojure.core$load_libs.doInvoke(core.clj:6000)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:669)
	at clojure.core$require.invokeStatic(core.clj:6038)
	at clojure.core$require.doInvoke(core.clj:6038)
	at clojure.lang.RestFn.invoke(RestFn.java:408)
	at user$eval5.invokeStatic(form-init16604705523553863047.clj:1)
	at user$eval5.invoke(form-init16604705523553863047.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7194)
	at clojure.lang.Compiler.eval(Compiler.java:7183)
	at clojure.lang.Compiler.eval(Compiler.java:7183)
	at clojure.lang.Compiler.load(Compiler.java:7653)
	at clojure.lang.Compiler.loadFile(Compiler.java:7591)
	at clojure.main$load_script.invokeStatic(main.clj:475)
	at clojure.main$init_opt.invokeStatic(main.clj:477)
	at clojure.main$init_opt.invoke(main.clj:477)
	at clojure.main$initialize.invokeStatic(main.clj:508)
	at clojure.main$null_opt.invokeStatic(main.clj:542)
	at clojure.main$null_opt.invoke(main.clj:539)
	at clojure.main$main.invokeStatic(main.clj:664)
	at clojure.main$main.doInvoke(main.clj:616)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:40)
, borrowedCount=0, returnedCount=0, createdCount=0, destroyedCount=0, destroyedByEvictorCount=0, destroyedByBorrowValidationCount=0, activeTimes=StatsStore [[]], size=100, index=0], idleTimes=StatsStore [[]], size=100, index=0], waitTimes=StatsStore [[]], size=100, index=0], maxBorrowWaitDuration=PT0S, swallowedExceptionListener=null, maxIdlePerKey=16, minIdlePerKey=0, maxTotalPerKey=16, factory=taoensso.carmine.connections$make_connection_factory$reify__7479@75189979, fairness=false, poolMap={}, poolKeyList=[], keyLock=java.util.concurrent.locks.ReentrantReadWriteLock@a89982a[Write locks = 0, Read locks = 0], numTotal=0, evictionKeyIterator=null, evictionKey=null, abandonedConfig=null]
```
</p>
</details> 

The same example as above but without unquoting returns the correct result:
```clojure 
(defmacro wcar* [& body] `(car/wcar my-wcar-opts ~@body))
(wcar* (car/ping))
```