### PR TITLE
Adding max message size to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ And as always **please report any unexpected problems** - thank you! 🙏
 
 ## New since `v3.3.2` (2023-10-24)
 
-* 8196415f [new] Update Redis command spec (2024-05-27)
+* 12c4100d [new] Update Redis command spec (2024-05-27)
 * Several wiki and docstring improvements
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ See [here][GitHub releases] for earlier releases.
 ## Why Carmine?
 
 - High-performance **pure-Clojure** library
-- [Fully documented API](#documentation) with support for the **latest Redis commands and features**
+- [Fully documented API](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine) with support for the **latest Redis commands and features**
 - Easy-to-use, production-ready **connection pooling**
 - Auto **de/serialization** of Clojure data types via [Nippy](https://www.taoensso.com/nippy)
-- Fast, simple **message queue** API
-- Fast, simple **distributed lock** API
+- Fast, simple [message queue](../../wiki/3-Message-queue) API
+- Fast, simple [distributed lock](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.locks) API
 
 ## Documentation
 

--- a/src/taoensso/carmine/connections.clj
+++ b/src/taoensso/carmine/connections.clj
@@ -1,6 +1,7 @@
 (ns taoensso.carmine.connections
-  "Handles socket connection lifecycle. Pool is implemented with Apache Commons
-  pool. Originally adapted from redis-clojure."
+  "Handles socket connection lifecycle.
+  Pool is implemented with Apache Commons pool.
+  Originally adapted from `redis-clojure`."
   {:author "Peter Taoussanis"}
   (:require
    [clojure.string            :as str]

--- a/src/taoensso/carmine/locks.clj
+++ b/src/taoensso/carmine/locks.clj
@@ -1,14 +1,15 @@
 (ns taoensso.carmine.locks
   "Alpha - subject to change.
-  Distributed lock implementation for Carmine based on work by Ronen Narkis
-  and Josiah Carlson. Redis 2.6+.
+  Distributed lock implementation for Carmine.
+  Based on work by Ronen Narkis and Josiah Carlson.
 
   Redis keys:
     * carmine:lock:<lock-name> -> ttl str, lock owner's UUID.
 
-  Ref. http://goo.gl/5UalQ for implementation details."
-  (:require [taoensso.timbre  :as timbre]
-            [taoensso.carmine :as car :refer (wcar)]))
+  Ref. <http://goo.gl/5UalQ> for implementation details."
+  (:require
+   [taoensso.timbre  :as timbre]
+   [taoensso.carmine :as car :refer (wcar)]))
 
 (def ^:private lkey (partial car/key :carmine :lock))
 

--- a/src/taoensso/carmine/message_queue.clj
+++ b/src/taoensso/carmine/message_queue.clj
@@ -85,7 +85,8 @@
       idx-qname-end     (- (count ":messages"))]
 
   (defn queue-names
-    "Returns a non-empty set of existing queue names, or nil."
+    "Returns a non-empty set of existing queue names, or nil.
+    Executes a Redis scan command, so O(n) of the number of keys in db."
     ([conn-opts        ] (queue-names conn-opts "*"))
     ([conn-opts pattern]
      (when-let [qks (not-empty (car/scan-keys conn-opts (qkey pattern :messages)))]
@@ -292,9 +293,9 @@
 ;;;; Implementation
 
 (do ; Lua scripts
-  (def lua-msg-status_ (delay (enc/have (enc/slurp-resource "taoensso/carmine/lua/mq/msg-status.lua"))))
-  (def lua-enqueue_    (delay (enc/have (enc/slurp-resource "taoensso/carmine/lua/mq/enqueue.lua"))))
-  (def lua-dequeue_    (delay (enc/have (enc/slurp-resource "taoensso/carmine/lua/mq/dequeue.lua")))))
+  (def ^:private lua-msg-status_ (delay (enc/have (enc/slurp-resource "taoensso/carmine/lua/mq/msg-status.lua"))))
+  (def ^:private lua-enqueue_    (delay (enc/have (enc/slurp-resource "taoensso/carmine/lua/mq/enqueue.lua"))))
+  (def ^:private lua-dequeue_    (delay (enc/have (enc/slurp-resource "taoensso/carmine/lua/mq/dequeue.lua")))))
 
 (defn message-status
   "Returns current message status, e/o:
@@ -607,7 +608,7 @@
 ;;;; Workers
 
 (defprotocol IWorker
-  "Implementation detail."
+  "Private, please don't use this."
   (^:no-doc start [this])
   (^:no-doc stop  [this]))
 

--- a/src/taoensso/carmine/ring.clj
+++ b/src/taoensso/carmine/ring.clj
@@ -1,9 +1,10 @@
 (ns taoensso.carmine.ring
   "Carmine-backed Ring session store."
   {:author "Peter Taoussanis"}
-  (:require [ring.middleware.session]
-            [taoensso.encore  :as enc]
-            [taoensso.carmine :as car :refer (wcar)]))
+  (:require
+   [ring.middleware.session]
+   [taoensso.encore  :as enc]
+   [taoensso.carmine :as car :refer [wcar]]))
 
 (defrecord CarmineSessionStore [conn-opts prefix ttl-secs extend-on-read?]
   ring.middleware.session.store/SessionStore
@@ -24,12 +25,13 @@
       k)))
 
 (defn carmine-store
-  "Creates and returns a Carmine-backed Ring SessionStore.
+  "Creates and returns a Carmine-backed Ring `SessionStore`.
+
   Options include:
-    :expiration-secs - How long session data should persist after last
-                       write. nil => persist forever.
-    :extend-on-read? - If true, expiration will also be extended by
-                       session reads."
+    `:expiration-secs` - How long session data should persist after last
+                         write. nil => persist forever.
+    `:extend-on-read?` - If true, expiration will also be extended by
+                         session reads."
   [conn-opts & [{:keys [key-prefix expiration-secs extend-on-read?]
                  :or   {key-prefix      "carmine:session"
                         expiration-secs (enc/secs :days 30)
@@ -37,8 +39,8 @@
   (->CarmineSessionStore conn-opts key-prefix expiration-secs extend-on-read?))
 
 (enc/deprecated
-  (defn ^:deprecated make-carmine-store ; 1.x backwards compatiblity
-    "DEPRECATED. Use `carmine-store` instead."
+  (defn ^:no-doc ^:deprecated make-carmine-store ; 1.x backwards compatiblity
+    "Prefer `carmine-store`."
     [& [s1 s2 & sn :as args]]
     (if (instance? taoensso.carmine.connections.ConnectionPool s1)
       (carmine-store {:pool s1 :spec s2} (apply hash-map sn))

--- a/wiki/0-Breaking-changes.md
+++ b/wiki/0-Breaking-changes.md
@@ -8,7 +8,7 @@ Thanks for your understanding - [Peter Taoussanis](https://www.taoensso.com)
 
 There are **breaking changes** to the **Carmine message queue API** that **may affect** a small proportion of message queue users.
 
-- If you **DO NOT** use Carmine's [message queue API](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html), no migration should be necessary.
+- If you **DO NOT** use Carmine's [message queue API](https://github.com/taoensso/carmine/wiki/3-Message-queue), no migration should be necessary.
 - If you **DO** use Carmine's message queue API, **please read the below checklist carefully**!!
 
 ## Migration checklist for message queue users
@@ -29,9 +29,9 @@ There are **breaking changes** to the **Carmine message queue API** that **may a
    
    The fn now **always returns a map** with `{:keys [success? mid action error]}`.
    
-   See the updated `enqueue` [docstring](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-enqueue) for details.
+   See the updated `enqueue` [docstring](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#enqueue) for details.
    
-3. [`queue-status`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queue-status) **return value has changed**.
+3. [`queue-status`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queue-status) **return value has changed**.
    
    This change is relevant to you iff you use the `queue-status` util.
    
@@ -40,7 +40,7 @@ There are **breaking changes** to the **Carmine message queue API** that **may a
    The fn now returns a small map in O(1) with `{:keys [nwaiting nlocked nbackoff ntotal]}`.
    
    If you want the detailed map of all queue content in O(queue-size),
-   use the new [`queue-content`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queue-content) util.
+   use the new [`queue-content`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queue-content) util.
    
 4. **The definition of "queue-size" has changed**.
    
@@ -51,9 +51,9 @@ There are **breaking changes** to the **Carmine message queue API** that **may a
    
    Most users won't be negatively affected by this change since the new definition better corresponds to how most users actually understood the term before.
    
-5. [`clear-queues`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-clear-queues) **has been deprecated**.
+5. `clear-queues` **has been deprecated**.
 
-   This utility is now called [`queues-clear!!`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queues-clear.21.21) to better match the rest of the API.
+   This utility is now called [`queues-clear!!`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queues-clear!!) to better match the rest of the API.
    
 6. **Handling order of queued messages has changed**.
 
@@ -75,7 +75,7 @@ There are **breaking changes** to the **Carmine message queue API** that **may a
   
   The default `:throttle-ms` value is now `:auto`, which uses such a function.
   
-  See the updated `worker` [docstring](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-worker) for details.
+  See the updated `worker` [docstring](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#worker) for details.
 
 - **Worker threads are now auto desynchronized** to reduce contention.
 
@@ -85,7 +85,7 @@ There are **breaking changes** to the **Carmine message queue API** that **may a
 - Added `enqueue` option: `:can-update?` to support **message updating**.
 - Handler fn data now includes `:worker`, `:queue-size` keys.
 - Handler fn data now includes `:age-ms` key, enabling **easy integration with Tufte or other profiling tools**.
-- Added utils: [`queue-size`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queue-size), [`queue-names`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queue-names), [`queue-content`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queue-content), [`queues-clear!!`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queues-clear.21.21), [`queues-clear-all!!!`](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-queues-clear-all.21.21.21).
+- Added utils: [`queue-size`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queue-size), [`queue-names`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queue-names), [`queue-content`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queue-content), [`queues-clear!!`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queues-clear!!), [`queues-clear-all!!!`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#queues-clear-all!!!).
 - `Worker` object's string/pprint representation is now more useful.
 - `Worker` object can now be derefed to get **state and stats useful for monitoring**.
   
@@ -93,7 +93,7 @@ There are **breaking changes** to the **Carmine message queue API** that **may a
 
 - `Worker` objects can now be invoked as fns to execute common actions.
   
-  Actions [include](https://taoensso.github.io/carmine/taoensso.carmine.message-queue.html#var-worker): `:start`, `:stop`, `:queue-size`, `:queue-status`.
+  Actions [include](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.message-queue#worker): `:start`, `:stop`, `:queue-size`, `:queue-status`.
 
 - Various improvements to docstrings, error messages, and logging output.
 - Improved message queue [state diagram](https://github.com/taoensso/carmine/blob/master/mq-architecture.svg).

--- a/wiki/1-Getting-started.md
+++ b/wiki/1-Getting-started.md
@@ -31,7 +31,7 @@ This `my-wcar-opts` can then be provided to Carmine's `wcar` ("with Carmine") AP
 (wcar my-wcar-opts (car/ping)) ; => "PONG"
 ```
 
-`wcar` is the main entry-point to Carmine's API. See its [docstring](https://taoensso.github.io/carmine/taoensso.carmine.html#var-wcar) for **lots more info** on connection options!
+`wcar` is the main entry-point to Carmine's API. See its [docstring](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#wcar) for **lots more info** on connection options!
 
 You can create a `wcar` partial for convenience:
 
@@ -106,7 +106,7 @@ Keywords | Redis strings
 Simple numbers | Redis strings
 Everything else | Auto de/serialized with [Nippy](https://www.taoensso.com/nippy)
 
-You can force automatic de/serialization for an argument of any type by wrapping it with [`car/freeze`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-freeze).
+You can force automatic de/serialization for an argument of any type by wrapping it with [`car/freeze`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#freeze).
 
 ## Command coverage
 
@@ -127,7 +127,7 @@ Time complexity: O(N+M*log(M)) where N is the number of elements in the list or 
 
 Each Carmine release will always use the latest Redis command spec.
 
-But if a new Redis command hasn't yet made it to Carmine, or if you want to use a Redis command not in the official spec (a [Redis module](https://redis.io/resources/modules/) command for example) - you can always use Carmine's [`redis-call`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-redis-call) function to issue **arbitrary Redis commands**.
+But if a new Redis command hasn't yet made it to Carmine, or if you want to use a Redis command not in the official spec (a [Redis module](https://redis.io/resources/modules/) command for example) - you can always use Carmine's [`redis-call`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#redis-call) function to issue **arbitrary Redis commands**.
 
 So you're **not constrained** by the commands provided by Carmine.
 

--- a/wiki/2-Further-usage.md
+++ b/wiki/2-Further-usage.md
@@ -18,11 +18,11 @@ As an example, let's write our own version of the `set` command:
 => ["OK" "lua bar"]
 ```
 
-Script primitives are also provided: [`eval`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-eval), [`eval-sha`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-evalsha), [`eval*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-eval*), [`eval-sha*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-evalsha*).
+Script primitives are also provided: [`eval`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#eval), [`eval-sha`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-evalsha), [`eval*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-eval*), [`eval-sha*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-evalsha*).
 
 # Helpers
 
-The [`lua`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-lua) command above is a good example of a Carmine "helper".
+The [`lua`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#lua) command above is a good example of a Carmine "helper".
 
 Carmine will never surprise you by interfering with the standard Redis command API. But there are times when it might want to offer you a helping hand (if you want it). Compare:
 
@@ -31,9 +31,9 @@ Carmine will never surprise you by interfering with the standard Redis command A
 (wcar* (car/zunionstore* "dest-key"  ["zset1" "zset2" "zset3"] "WEIGHTS" 2 3 5))
 ```
 
-Both of these calls are equivalent but the latter counted the keys for us. [`zunionstore*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-zunionstore*) is another helper: a slightly more convenient version of a standard command, suffixed with a `*` to indicate that it's non-standard.
+Both of these calls are equivalent but the latter counted the keys for us. [`zunionstore*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#zunionstore*) is another helper: a slightly more convenient version of a standard command, suffixed with a `*` to indicate that it's non-standard.
 
-Helpers currently include: [`atomic`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-atomic), [`eval*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-eval*), [`evalsha*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-evalsha*), [`info*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-info*), [`lua`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-lua), [`sort*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-sort*), [`zinterstore*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-zinterstore*), and [`zunionstore*`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-zunionstore*).
+Helpers currently include: [`atomic`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#atomic), [`eval*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#eval*), [`evalsha*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#evalsha*), [`info*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#info*), [`lua`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#lua), [`sort*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#sort*), [`zinterstore*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#zinterstore*), and [`zunionstore*`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#zunionstore*).
 
 # Pub/Sub and Listeners
 
@@ -88,7 +88,7 @@ Note that subscriptions are **connection-local**: you can have three different l
 
 # Reply parsing
 
-Want a little more control over how server replies are parsed? See [`parse`](https://taoensso.github.io/carmine/taoensso.carmine.html#var-parse):
+Want a little more control over how server replies are parsed? See [`parse`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine#parse):
 
 ```clojure
 (wcar*
@@ -100,7 +100,7 @@ Want a little more control over how server replies are parsed? See [`parse`](htt
 
 # Distributed locks
 
-See the [`locks`](https://taoensso.github.io/carmine/taoensso.carmine.locks.html) namespace for a simple distributed lock API:
+See the [`locks`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.locks) namespace for a simple distributed lock API:
 
 ```clojure
 (:require [taoensso.carmine.locks :as locks]) ; Add to `ns` macro
@@ -119,21 +119,21 @@ See the [`locks`](https://taoensso.github.io/carmine/taoensso.carmine.locks.html
 
 Redis is a beautifully designed datastore that makes some explicit engineering tradeoffs. Probably the most important: your data _must_ fit in memory. Tundra helps relax this limitation: only your **hot** data need fit in memory. How does it work?
 
- 1. Use Tundra's [`dirty`](https://taoensso.github.io/carmine/taoensso.carmine.tundra.html#var-dirty) command **any time you modify/create evictable keys**
- 2. Use [`worker`](https://taoensso.github.io/carmine/taoensso.carmine.tundra.html#var-worker) to create a threaded worker that'll **automatically replicate dirty keys to your secondary datastore**
+ 1. Use Tundra's [`dirty`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra#dirty) command **any time you modify/create evictable keys**
+ 2. Use [`worker`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra#ITundraStore) to create a threaded worker that'll **automatically replicate dirty keys to your secondary datastore**
  3. When a dirty key hasn't been used in a specified TTL, it will be **automatically evicted from Redis** (eviction is optional if you just want to use Tundra as a backup/just-in-case mechanism)
- 4. Use [`ensure-ks`](https://taoensso.github.io/carmine/taoensso.carmine.tundra.html#var-ensure-ks) **any time you want to use evictable keys** - this'll extend their TTL or fetch them from your datastore as necessary
+ 4. Use [`ensure-ks`](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra#ensure-ks) **any time you want to use evictable keys** - this'll extend their TTL or fetch them from your datastore as necessary
 
 That's it: two Redis commands, and a worker!
 
-Tundra uses Redis' own dump/restore mechanism for replication, and Carmine's own [[Message queue|message queue]] to coordinate the replication worker.
+Tundra uses Redis' own dump/restore mechanism for replication, and Carmine's own [Message queue](./3-Message-queue) to coordinate the replication worker.
 
 It's possible to easily extend support to **any K/V-capable datastore**.  
 Implementations are provided out-the-box for:
 
-- [Disk](https://taoensso.github.io/carmine/taoensso.carmine.tundra.disk.html)
-- [Amazon S3](https://taoensso.github.io/carmine/taoensso.carmine.tundra.s3.html)
-- [Amazon DynamoDB](https://taoensso.github.io/carmine/taoensso.carmine.tundra.faraday.html) via [Faraday](https://www.taoensso.com/faraday)
+- [Disk](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra.disk)
+- [Amazon S3](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra.s3)
+- [Amazon DynamoDB](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra.faraday) via [Faraday](https://www.taoensso.com/faraday)
 
 ## Example usage
 
@@ -155,4 +155,4 @@ Implementations are provided out-the-box for:
 )
 ```
 
-Note that the [Tundra API](https://taoensso.github.io/carmine/taoensso.carmine.tundra.html) makes it convenient to use several different datastores simultaneously (perhaps for different purposes with different latency requirements).
+Note that the [Tundra API](https://cljdoc.org/d/com.taoensso/carmine/CURRENT/api/taoensso.carmine.tundra) makes it convenient to use several different datastores simultaneously (perhaps for different purposes with different latency requirements).

--- a/wiki/3-Message-queue.md
+++ b/wiki/3-Message-queue.md
@@ -29,6 +29,7 @@ See linked docstrings below for features and usage:
 
 (wcar* (car-mq/enqueue "my-queue" "my message!"))
 
+;; Deref your worker to get detailed status info
 @my-worker =>
 {:qname     "my-queue"
  :opts      <opts-map>
@@ -55,4 +56,4 @@ The following semantics are provided:
 - Messages are **handled once and only once**.
 - Messages are **handled in loose order** (exact order may be affected by the number of concurrent handler threads, and retry/backoff features, etc.).
 - Messages are **fault-tolerant** (preserved until acknowledged as handled).
-- Messages support optional per-message **de-duplication**, preventing the same message from being simultaneously queued more than once within a specifiable backoff period.
+- Messages support optional per-message **de-duplication**, preventing the same message from being simultaneously queued more than once within a configurable per-message backoff period.

--- a/wiki/3-Message-queue.md
+++ b/wiki/3-Message-queue.md
@@ -57,3 +57,4 @@ The following semantics are provided:
 - Messages are **handled in loose order** (exact order may be affected by the number of concurrent handler threads, and retry/backoff features, etc.).
 - Messages are **fault-tolerant** (preserved until acknowledged as handled).
 - Messages support optional per-message **de-duplication**, preventing the same message from being simultaneously queued more than once within a configurable per-message backoff period.
+- Messages are encoded using [nippy](https://github.com/taoensso/nippy) and stored as string values in Redis hashes. Each message (after being encoded) may have a max size of 512MB


### PR DESCRIPTION
Also noting that messages are encoded using `nippy`, just in case that matters for someone getting close to the max size.