### PR TITLE
Fix a couple typos in the Wiki

### DIFF
--- a/wiki/2-Further-usage.md
+++ b/wiki/2-Further-usage.md
@@ -46,7 +46,7 @@ Carmine has a flexible **listener API** to support persistent-connection feature
      "channel*" (fn f2 [msg] (println "f2:" msg))
      "ch*"      (fn f3 [msg] (println "f3:" msg))}
    (car/subscribe  "channel1")
-   (car/psubscribe "channel*" "ch*)))
+   (car/psubscribe "channel*" "ch*")))
 ```
 
 Exactly 1 handler fn will trigger per published message *exactly* matching each active subscription:

--- a/wiki/2-Further-usage.md
+++ b/wiki/2-Further-usage.md
@@ -70,7 +70,7 @@ So publishing to "channel1" in this example will trigger all 3x handlers:
 You can adjust subscriptions and/or handlers:
 
 ```clojure
-(with-open-listener my-listener
+(car/with-open-listener my-listener
   (car/unsubscribe) ; Unsubscribe from every channel (leaving patterns alone)
   (car/subscribe "channel3"))
 


### PR DESCRIPTION
- Added a missing quote
- Added a missing namespace