### PR TITLE
Zero thread worker support

### DIFF
--- a/src/taoensso/carmine/message_queue.clj
+++ b/src/taoensso/carmine/message_queue.clj
@@ -674,14 +674,16 @@
 
   IWorker
   (stop [_]
-    (when (compare-and-set! running?_ true false)
+    (when (and (pos-int? (get worker-opts :nthreads-worker))
+               (compare-and-set! running?_ true false))
       (timbre/info "[Carmine/mq] Queue worker shutting down" {:qname qname})
       (run! deref @worker-futures_)
       (timbre/info "[Carmine/mq] Queue worker has shut down" {:qname qname})
       true))
 
   (start [this]
-    (when (compare-and-set! running?_ false true)
+    (when (and (pos-int? (get worker-opts :nthreads-worker))
+               (compare-and-set! running?_ false true))
       (timbre/info "[Carmine/mq] Queue worker starting" {:qname qname})
       (let [{:keys [handler monitor nthreads-worker]} worker-opts
             qk (partial qkey qname)

--- a/src/taoensso/carmine/message_queue.clj
+++ b/src/taoensso/carmine/message_queue.clj
@@ -919,7 +919,7 @@
          (CarmineMessageQueueWorker.
            qname worker-opts conn-opts
            (atom false)
-           (enc/future-pool nthreads-handler)
+           (when (pos-int? nthreads-handler) (enc/future-pool nthreads-handler))
            (atom [])
            (atom {})
 


### PR DESCRIPTION
Resolves #315 

- ensures nop when starting/stopping zero-thread workers
- create future-pool only when worker has threads since future-pool isn't designed to handle 0 as the value for nthreads
- added tests for zero thread workers that ensure that
    - handler-fn is never called
    - messages from the queue aren't processed
    - starting worker doesn't change the value of `@running?`